### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,6 +3,9 @@ name: pre-commit
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/antarctic/security/code-scanning/9](https://github.com/tschm/antarctic/security/code-scanning/9)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow appears to perform read-only operations (e.g., running pre-commit checks and building a virtual environment), we will set the permissions to `contents: read`. This ensures that the `GITHUB_TOKEN` has only the minimal permissions required for the workflow to function.

The `permissions` block will be added at the root level of the workflow, so it applies to all jobs (`pre-commit` and `deptry`) unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
