### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: "CI"
 on:
 - push
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # The type of runner that the job will run on


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/antarctic/security/code-scanning/2](https://github.com/tschm/antarctic/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow appears to perform basic CI tasks such as building a virtual environment and running tests, it likely only requires `contents: read` permissions. This change will ensure that the workflow has the minimum necessary permissions to execute its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
