### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   pdoc:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: tschm/cradle/actions/environment@v0.1.73
@@ -17,9 +19,10 @@ jobs:
         with:
           source-folder: src/antarctic
 
-
   test:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       # uses MongoMock
       #- name: Start MongoDB


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/antarctic/security/code-scanning/5](https://github.com/tschm/antarctic/security/code-scanning/5)

To fix the issue, we need to add a `permissions` key to the `pdoc` and `test` jobs, specifying the least privileges required for their respective tasks. For the `pdoc` job, it likely only needs `contents: read` to access the source folder, and for the `test` job, it might also need `contents: read` to access test files. These explicit permissions will replace the default repository permissions and restrict access to only what's necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
