### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   marimo:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - uses: jebel-quant/marimushka@v0.1.2
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/antarctic/security/code-scanning/10](https://github.com/tschm/antarctic/security/code-scanning/10)

To fix the issue, we need to add a `permissions` block to the `marimo` job, specifying the least privileges required. If the job does not manipulate repository contents or require write access, we set `contents: read`. If no permissions are needed, we can set `permissions: {}` to explicitly indicate no permissions are granted. This ensures that the job adheres to the principle of least privilege and mitigates potential risks.

The change will be made in the `.github/workflows/book.yml` file by adding the `permissions` block under the `marimo` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
