### PR TITLE
Add PolarsField for storing polars DataFrames in MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/tschm/antarctic/badge)](https://www.codefactor.io/repository/github/tschm/antarctic)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://github.com/renovatebot/renovate)
 
-Project to persist Pandas data structures in a MongoDB database.
+Project to persist Pandas and Polars data structures in a MongoDB database.
 
 ## Installation
 
@@ -18,15 +18,15 @@ pip install antarctic
 
 ## Usage
 
-This project (unless the popular arctic project which I admire)
+This project (unlike the popular arctic project which I admire)
 is based on top of [MongoEngine](https://pypi.org/project/mongoengine/).
 MongoEngine is an ORM for MongoDB. MongoDB stores documents.
-We introduce a new field and extend the Document class
-to make Antarctic a convenient choice for storing Pandas (time series) data.
+We introduce new fields and extend the Document class
+to make Antarctic a convenient choice for storing Pandas and Polars (time series) data.
 
-### Fields
+### PandasField
 
-We introduce first a new field --- the PandasField.
+We introduce first the PandasField for storing Pandas DataFrames.
 
 ```python
 import mongomock
@@ -72,7 +72,44 @@ store them in a MongoDB database.
 
 The format should also be readable by R.
 
-#### Documents
+### PolarsField
+
+Antarctic also supports storing Polars DataFrames using the PolarsField.
+
+```python
+import polars as pl
+from mongoengine import Document, StringField
+from antarctic.polars_field import PolarsField
+
+class Artist(Document):
+    name = StringField(unique=True, required=True)
+    data = PolarsField()
+
+```
+
+The PolarsField works similarly to PandasField:
+
+```python
+a = Artist(name="Artist1")
+a.data = pl.DataFrame({"A": [2.0, 2.0], "B": [2.0, 2.0]})
+a.save()
+
+# Retrieve the data
+df = a.data
+
+```
+
+PolarsField uses zstd compression by default for efficient storage,
+but you can specify other compression algorithms:
+
+```python
+class CustomArtist(Document):
+    name = StringField(unique=True, required=True)
+    data = PolarsField(compression="snappy")  # Options: lz4, uncompressed, snappy, gzip, brotli, zstd
+
+```
+
+### XDocument
 
 In most cases we have copies of very similar documents,
 e.g. we store Portfolios and Symbols rather than just a Portfolio or a Symbol.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ dependencies = [
     "mongoengine>=0.25.0",
     "pandas>=2.0",
     "pyarrow>=22.0.0",
-    "fastparquet>=0.8.0"
+    "fastparquet>=0.8.0",
+    "polars>=1.37.1",
 ]
 authors = [{name = "Thomas Schmelzer", email = "thomas.schmelzer@gmail.com"}]
 
@@ -33,7 +34,7 @@ packages = ["src/antarctic"]
 
 [tool.mypy]
 [[tool.mypy.overrides]]
-module = ["pandas.*", "pyarrow.*", "mongoengine.*", "bson.*"]
+module = ["pandas.*", "pyarrow.*", "mongoengine.*", "bson.*", "polars.*"]
 ignore_missing_imports = true
 
 [tool.deptry.package_module_name_map]
@@ -45,6 +46,7 @@ mongomock = "mongomock"
 plotly = "plotly"
 numpy = "numpy"
 marimo = "marimo"
+polars = "polars"
 
 [tool.deptry.per_rule_ignores]
 # bson is part of pymongo package and should not be installed separately

--- a/src/antarctic/polars_field.py
+++ b/src/antarctic/polars_field.py
@@ -1,0 +1,136 @@
+"""Provide a custom Polars field type for MongoEngine.
+
+It allows storing polars DataFrames in MongoDB by converting them to and from
+parquet-formatted byte streams. This enables efficient storage and retrieval
+of polars data structures within MongoDB documents.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Any, Literal
+
+import polars as pl
+from mongoengine.base import BaseField
+
+CompressionType = Literal["lz4", "uncompressed", "snappy", "gzip", "brotli", "zstd"]
+
+
+def _read(value: bytes, columns: list[str] | None = None) -> pl.DataFrame:
+    """Read a DataFrame from its binary parquet representation.
+
+    Args:
+        value: Binary representation of a DataFrame stored as parquet
+        columns: Optional list of column names to load (loads all columns if None)
+
+    Returns:
+        pl.DataFrame: The reconstructed polars DataFrame
+
+    Examples:
+        >>> import polars as pl
+        >>> df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        >>> data = _write(df)
+        >>> result = _read(data)
+        >>> result["a"].to_list()
+        [1, 2, 3]
+
+        Select specific columns:
+
+        >>> result = _read(data, columns=["b"])
+        >>> result.columns
+        ['b']
+
+    """
+    return pl.read_parquet(BytesIO(value), columns=columns)
+
+
+def _write(value: pl.DataFrame, compression: CompressionType = "zstd") -> bytes:
+    """Convert a Polars DataFrame into a compressed parquet byte-stream.
+
+    The byte-stream encodes in its metadata the structure of the Polars object,
+    including column names and data types.
+
+    Args:
+        value: The DataFrame to convert
+        compression: Compression algorithm to use (default: "zstd")
+
+    Returns:
+        bytes: Binary representation of the DataFrame in parquet format
+
+    Examples:
+        >>> import polars as pl
+        >>> df = pl.DataFrame({"x": [1.0, 2.0], "y": [3.0, 4.0]})
+        >>> data = _write(df)
+        >>> isinstance(data, bytes)
+        True
+        >>> data[:4]  # Parquet magic bytes
+        b'PAR1'
+
+    """
+    buffer = BytesIO()
+    value.write_parquet(buffer, compression=compression)
+    return buffer.getvalue()
+
+
+class PolarsField(BaseField):  # type: ignore[misc]
+    """Custom MongoEngine field type for storing polars DataFrames.
+
+    This field handles the conversion between polars DataFrames and binary data
+    that can be stored in MongoDB. It uses parquet format for efficient storage
+    and retrieval of tabular data.
+    """
+
+    def __init__(self, compression: CompressionType = "zstd", **kwargs: Any) -> None:
+        """Initialize a PolarsField.
+
+        Args:
+            compression: Compression algorithm to use for parquet storage (default: "zstd")
+            **kwargs: Additional arguments passed to the parent BaseField
+
+        """
+        super().__init__(**kwargs)
+        self.compression = compression
+
+    def __set__(self, instance: Any, value: pl.DataFrame | bytes | None) -> None:
+        """Convert and set the value for this field.
+
+        If the value is a DataFrame, it's converted to a parquet byte stream.
+        If it's already bytes, it's stored as-is.
+
+        Args:
+            instance: The document instance
+            value: The value to set (DataFrame, bytes, or None)
+
+        Raises:
+            TypeError: If the value is neither a DataFrame, bytes, nor None
+
+        """
+        if value is not None:
+            if isinstance(value, pl.DataFrame):
+                # Convert DataFrame to binary format for storage
+                value = _write(value, compression=self.compression)
+            elif isinstance(value, bytes):
+                # Already in binary format, store as-is
+                pass
+            else:
+                msg = f"Type of value {type(value)} not supported. Expected DataFrame or bytes."
+                raise TypeError(msg)
+        super().__set__(instance, value)
+
+    def __get__(self, instance: Any, owner: type) -> pl.DataFrame | None:
+        """Retrieve and convert the stored value back to a DataFrame.
+
+        Args:
+            instance: The document instance
+            owner: The document class
+
+        Returns:
+            Optional[pl.DataFrame]: The retrieved DataFrame or None if no data
+
+        """
+        data = super().__get__(instance, owner)
+
+        if data is not None:
+            return _read(data)
+
+        return None

--- a/src/antarctic/polars_field.py
+++ b/src/antarctic/polars_field.py
@@ -117,17 +117,22 @@ class PolarsField(BaseField):  # type: ignore[misc]
                 raise TypeError(msg)
         super().__set__(instance, value)
 
-    def __get__(self, instance: Any, owner: type) -> pl.DataFrame | None:
+    def __get__(self, instance: Any, owner: type) -> pl.DataFrame | PolarsField | None:
         """Retrieve and convert the stored value back to a DataFrame.
 
         Args:
-            instance: The document instance
+            instance: The document instance (None for class-level access)
             owner: The document class
 
         Returns:
-            Optional[pl.DataFrame]: The retrieved DataFrame or None if no data
+            PolarsField: The descriptor itself when accessed at class level
+            pl.DataFrame: The retrieved DataFrame when accessed on an instance
+            None: If no data is stored
 
         """
+        if instance is None:
+            return self
+
         data = super().__get__(instance, owner)
 
         if data is not None:

--- a/tests/test_antarctic/test_polarsfield.py
+++ b/tests/test_antarctic/test_polarsfield.py
@@ -1,0 +1,81 @@
+"""Tests for the PolarsField class functionality.
+
+This module contains tests for the PolarsField class, which is a custom MongoEngine
+field type for storing polars DataFrames in MongoDB. The tests verify that the field
+correctly handles different types of polars objects and properly validates input.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from mongoengine import Document, StringField
+from polars.testing import assert_frame_equal
+from pymongo.mongo_client import MongoClient
+
+from antarctic.polars_field import PolarsField
+
+
+class Artist(Document):
+    """Test document class that uses PolarsField.
+
+    This class is used for testing the functionality of the PolarsField class.
+    It represents an artist with a data field that stores polars data.
+    """
+
+    name = StringField(unique=True, required=True)
+    data = PolarsField()
+
+
+def test_write_frame(client: MongoClient) -> None:
+    """Test storing and retrieving a DataFrame in a PolarsField.
+
+    This test verifies that a polars DataFrame can be stored in a PolarsField
+    and retrieved with the same structure and data.
+
+    Args:
+        client: MongoDB client fixture
+
+    """
+    # Create a document with a DataFrame in the PolarsField
+    a = Artist(name="Artist1")
+    a.data = pl.DataFrame({"A": [2.0, 2.0], "B": [2.0, 2.0]})
+    a.save()
+
+    # Verify that the retrieved DataFrame matches the original
+    assert_frame_equal(a.data, pl.DataFrame({"A": [2.0, 2.0], "B": [2.0, 2.0]}))
+
+
+def test_write_non_polars(client: MongoClient) -> None:
+    """Test that non-polars objects cannot be stored in a PolarsField.
+
+    This test verifies that attempting to store a non-polars object
+    (like a list) in a PolarsField raises a TypeError.
+
+    Args:
+        client: MongoDB client fixture
+
+    """
+    # Attempt to store a list in a PolarsField
+    # This should raise a TypeError
+    a = Artist(name="Artist2")
+    with pytest.raises(TypeError):
+        a.data = [2.0, 2.0]
+
+
+def test_write_none(client: MongoClient) -> None:
+    """Test that None can be stored in a PolarsField.
+
+    This test verifies that None can be stored and retrieved from a PolarsField.
+
+    Args:
+        client: MongoDB client fixture
+
+    """
+    # Create a document with None in the PolarsField
+    a = Artist(name="Artist3")
+    a.data = None
+    a.save()
+
+    # Verify that the retrieved value is None
+    assert a.data is None

--- a/tests/test_antarctic/test_polarsfield.py
+++ b/tests/test_antarctic/test_polarsfield.py
@@ -83,3 +83,15 @@ def test_write_none(client: MongoClient) -> None:
     # Reload from database to verify full serialization/deserialization cycle
     reloaded = Artist.objects.get(name="Artist3")
     assert reloaded.data is None
+
+
+def test_class_level_access() -> None:
+    """Test that class-level access returns the descriptor itself.
+
+    This test verifies that accessing the PolarsField on the class
+    (e.g., Artist.data) returns the PolarsField descriptor rather than
+    attempting to read data.
+
+    """
+    # Accessing the field on the class should return the descriptor
+    assert isinstance(Artist.data, PolarsField)

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ dependencies = [
     { name = "fastparquet" },
     { name = "mongoengine" },
     { name = "pandas" },
+    { name = "polars" },
     { name = "pyarrow" },
 ]
 
@@ -34,6 +35,7 @@ requires-dist = [
     { name = "fastparquet", specifier = ">=0.8.0" },
     { name = "mongoengine", specifier = ">=0.25.0" },
     { name = "pandas", specifier = ">=2.0" },
+    { name = "polars", specifier = ">=1.37.1" },
     { name = "pyarrow", specifier = ">=22.0.0" },
 ]
 
@@ -667,6 +669,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/4f/8a10a9b9f5192cb6fdef62f1d77fa7d834190b2c50c0cd256bd62879212b/plotly-6.5.2.tar.gz", hash = "sha256:7478555be0198562d1435dee4c308268187553cc15516a2f4dd034453699e393", size = 7015695, upload-time = "2026-01-14T21:26:51.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl", hash = "sha256:91757653bd9c550eeea2fa2404dba6b85d1e366d54804c340b2c874e5a7eb4a4", size = 9895973, upload-time = "2026-01-14T21:26:47.135Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.37.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/ae/dfebf31b9988c20998140b54d5b521f64ce08879f2c13d9b4d44d7c87e32/polars-1.37.1.tar.gz", hash = "sha256:0309e2a4633e712513401964b4d95452f124ceabf7aec6db50affb9ced4a274e", size = 715572, upload-time = "2026-01-12T23:27:03.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/75/ec73e38812bca7c2240aff481b9ddff20d1ad2f10dee4b3353f5eeaacdab/polars-1.37.1-py3-none-any.whl", hash = "sha256:377fed8939a2f1223c1563cfabdc7b4a3d6ff846efa1f2ddeb8644fafd9b1aff", size = 805749, upload-time = "2026-01-12T23:25:48.595Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.37.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/0b/addabe5e8d28a5a4c9887a08907be7ddc3fce892dc38f37d14b055438a57/polars_runtime_32-1.37.1.tar.gz", hash = "sha256:68779d4a691da20a5eb767d74165a8f80a2bdfbde4b54acf59af43f7fa028d8f", size = 2818945, upload-time = "2026-01-12T23:27:04.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a2/e828ea9f845796de02d923edb790e408ca0b560cd68dbd74bb99a1b3c461/polars_runtime_32-1.37.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0b8d4d73ea9977d3731927740e59d814647c5198bdbe359bcf6a8bfce2e79771", size = 43499912, upload-time = "2026-01-12T23:25:51.182Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/46/81b71b7aa9e3703ee6e4ef1f69a87e40f58ea7c99212bf49a95071e99c8c/polars_runtime_32-1.37.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c682bf83f5f352e5e02f5c16c652c48ca40442f07b236f30662b22217320ce76", size = 39695707, upload-time = "2026-01-12T23:25:54.289Z" },
+    { url = "https://files.pythonhosted.org/packages/81/2e/20009d1fde7ee919e24040f5c87cb9d0e4f8e3f109b74ba06bc10c02459c/polars_runtime_32-1.37.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc82b5bbe70ca1a4b764eed1419f6336752d6ba9fc1245388d7f8b12438afa2c", size = 41467034, upload-time = "2026-01-12T23:25:56.925Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/21/9b55bea940524324625b1e8fd96233290303eb1bf2c23b54573487bbbc25/polars_runtime_32-1.37.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8362d11ac5193b994c7e9048ffe22ccfb976699cfbf6e128ce0302e06728894", size = 45142711, upload-time = "2026-01-12T23:26:00.817Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/25/c5f64461aeccdac6834a89f826d051ccd3b4ce204075e562c87a06ed2619/polars_runtime_32-1.37.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:04f5d5a2f013dca7391b7d8e7672fa6d37573a87f1d45d3dd5f0d9b5565a4b0f", size = 41638564, upload-time = "2026-01-12T23:26:04.186Z" },
+    { url = "https://files.pythonhosted.org/packages/35/af/509d3cf6c45e764ccf856beaae26fc34352f16f10f94a7839b1042920a73/polars_runtime_32-1.37.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fbfde7c0ca8209eeaed546e4a32cca1319189aa61c5f0f9a2b4494262bd0c689", size = 44721136, upload-time = "2026-01-12T23:26:07.088Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d1/5c0a83a625f72beef59394bebc57d12637997632a4f9d3ab2ffc2cc62bbf/polars_runtime_32-1.37.1-cp310-abi3-win_amd64.whl", hash = "sha256:da3d3642ae944e18dd17109d2a3036cb94ce50e5495c5023c77b1599d4c861bc", size = 44948288, upload-time = "2026-01-12T23:26:10.214Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f3/061bb702465904b6502f7c9081daee34b09ccbaa4f8c94cf43a2a3b6dd6f/polars_runtime_32-1.37.1-cp310-abi3-win_arm64.whl", hash = "sha256:55f2c4847a8d2e267612f564de7b753a4bde3902eaabe7b436a0a4abf75949a0", size = 41001914, upload-time = "2026-01-12T23:26:12.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a custom MongoEngine field type for polars DataFrames, mirroring the existing PandasField implementation. Uses parquet format for efficient storage with configurable compression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a field type to store Polars DataFrames in MongoEngine documents with automatic serialize/deserialize and configurable compression (default zstd; lz4, gzip, snappy, brotli, uncompressed supported).

* **Tests**
  * Added tests covering read/write, type validation, and None handling for the new field.

* **Documentation**
  * README updated with Polars usage examples and guidance.

* **Chores**
  * Added Polars as a runtime dependency and updated type/dependency config.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->